### PR TITLE
fix(claude-code): symlink skill directories instead of writing path strings

### DIFF
--- a/nix/agents/claude-code/home-manager-module.nix
+++ b/nix/agents/claude-code/home-manager-module.nix
@@ -50,11 +50,19 @@ in
 
       agents = lib.mkDefault autoAgents;
 
-      skills = lib.mkMerge [
-        (lib.mkIf (autoSkills != { }) autoSkills)
-      ];
-
       mcpServers = lib.mkDefault autoMcpServers;
     };
+
+    # Wire skills as directory symlinks via home.file directly.
+    # programs.claude-code.skills uses `either lines path` which matches
+    # string store paths as `lines` (writing the path string as text).
+    # Using home.file with source creates proper directory symlinks.
+    home.file = lib.mkIf (autoSkills != { }) (
+      lib.mapAttrs' (name: path:
+        lib.nameValuePair ".claude/skills/${name}" {
+          source = path;
+        }
+      ) autoSkills
+    );
   };
 }

--- a/nix/agents/claude-code/test/flake.nix
+++ b/nix/agents/claude-code/test/flake.nix
@@ -65,9 +65,17 @@
           machine.succeed("test -d /home/testuser/.claude/skills/example")
           machine.succeed("test -d /home/testuser/.claude/skills/second-skill")
 
+          # Verify skill SKILL.md contains actual content, not a store path string
+          machine.succeed("grep -q 'Example Skill' /home/testuser/.claude/skills/example/SKILL.md")
+          machine.fail("grep -q '/nix/store' /home/testuser/.claude/skills/example/SKILL.md")
+
           # Verify agents from both dirs
           machine.succeed("test -f /home/testuser/.claude/agents/example.md")
           machine.succeed("test -f /home/testuser/.claude/agents/second.md")
+
+          # Verify agent files contain actual content, not a store path string
+          machine.succeed("grep -q 'Example Agent' /home/testuser/.claude/agents/example.md")
+          machine.fail("grep -q '/nix/store' /home/testuser/.claude/agents/example.md")
 
           # Verify commands from both dirs
           machine.succeed("test -f /home/testuser/.claude/commands/example.md")

--- a/nix/agents/opencode/test/flake.nix
+++ b/nix/agents/opencode/test/flake.nix
@@ -70,9 +70,17 @@
           machine.succeed("test -d /home/testuser/.config/opencode/skill/example")
           machine.succeed("test -d /home/testuser/.config/opencode/skill/second-skill")
 
+          # Verify skill SKILL.md contains actual content, not a store path string
+          machine.succeed("grep -q 'Example Skill' /home/testuser/.config/opencode/skill/example/SKILL.md")
+          machine.fail("grep -q '/nix/store' /home/testuser/.config/opencode/skill/example/SKILL.md")
+
           # Verify agents from both dirs
           machine.succeed("test -f /home/testuser/.config/opencode/agent/example.md")
           machine.succeed("test -f /home/testuser/.config/opencode/agent/second.md")
+
+          # Verify agent files contain actual content, not a store path string
+          machine.succeed("grep -q 'Example Agent' /home/testuser/.config/opencode/agent/example.md")
+          machine.fail("grep -q '/nix/store' /home/testuser/.config/opencode/agent/example.md")
 
           # Verify opencode.json is created
           machine.succeed("test -f /home/testuser/.config/opencode/opencode.json")

--- a/nix/autowire-lib.nix
+++ b/nix/autowire-lib.nix
@@ -43,7 +43,7 @@
         (fileName: _:
           lib.nameValuePair
             (lib.removeSuffix ".md" fileName)
-            (path + "/" + fileName)
+            (builtins.readFile (path + "/${fileName}"))
         )
         (builtins.readDir path));
 


### PR DESCRIPTION
## Summary

- `readSkills` returned raw path strings that `programs.claude-code.skills` (type: `attrsOf (either lines path)`) matched as `lines`, writing the path string verbatim as SKILL.md content instead of creating symlinks
- Fix: route autowired skills through `home.file` directly (bypassing the `skills` option), creating proper **directory symlinks** — matches how the opencode module already handles skills
- Also fixes `readAgentsPath` which had the same string-instead-of-content bug

## Root cause

`toString dir + "/skills"` produces a **string**. When this string flows into `programs.claude-code.skills`, home-manager's `either lines path` matches `lines` (not `path`), so the string is written as file text.

Returning nix path types would fix this, but flake input paths (`flakeInput + "/.agents"`) always produce strings (via `outPath` coercion), and nix prohibits converting store path strings back to path types.

## Fix

Route autowired skills through `home.file` directly instead of `programs.claude-code.skills`:

```nix
home.file = lib.mapAttrs' (name: path:
  lib.nameValuePair ".claude/skills/${name}" { source = path; }
) autoSkills;
```

This creates whole-directory symlinks, supports multi-file skills, and works with both local paths and flake input store path strings.

## Before / After

**Before:** `~/.claude/skills/nix-flake/SKILL.md` contains `/nix/store/abc.../.agents/skills/nix-flake`

**After:** `~/.claude/skills/nix-flake` → symlink to store directory with real SKILL.md content

## Test plan

- [x] `home-manager switch` succeeds
- [x] Skills are directory symlinks (not individual file symlinks)
- [x] `cat ~/.claude/skills/*/SKILL.md` shows real content
- [x] Both local (`./agents`) and flake input (`juspay-AI + "/.agents"`) skills work

🤖 Generated with [Claude Code](https://claude.com/claude-code)